### PR TITLE
Add: Herokuデプロイの為、Gemfile.lockファイルにプラットフォームを追加

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -99,6 +99,8 @@ GEM
     nio4r (2.5.8)
     nokogiri (1.13.6-x86_64-darwin)
       racc (~> 1.4)
+    nokogiri (1.13.6-x86_64-linux)
+      racc (~> 1.4)
     pg (1.3.5)
     puma (5.6.4)
       nio4r (~> 2.0)
@@ -184,6 +186,7 @@ GEM
 
 PLATFORMS
   x86_64-darwin-21
+  x86_64-linux
 
 DEPENDENCIES
   bootsnap (>= 1.4.4)


### PR DESCRIPTION
## 概要

・`bundle lock --add-platform x86_64-linux`を追記

## 確認方法

1. Gemfile.lockのPLATFORMSにx86_64-linuxが追記されていること。
