### PR TITLE
Create after login view

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,11 +2,9 @@
 
 class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
+  # deviseコントローラーにストロングパラメータを追加する
   before_action :configure_permitted_parameters, if: :devise_controller?
 
-  def after_sign_in_path_for(_resource)
-    tops_show_path
-  end
 
   private
 
@@ -16,8 +14,11 @@ class ApplicationController < ActionController::Base
 
   protected
 
+   
   def configure_permitted_parameters
+    # サインアップ時のストロングパラメータ
     devise_parameter_sanitizer.permit(:sign_up, keys: [:username])
+    # アカウント編集時のストロングパラメータ
     devise_parameter_sanitizer.permit(:account_update, keys: [:username])
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -5,7 +5,6 @@ class ApplicationController < ActionController::Base
   # deviseコントローラーにストロングパラメータを追加する
   before_action :configure_permitted_parameters, if: :devise_controller?
 
-
   private
 
   def sign_in_required
@@ -14,7 +13,6 @@ class ApplicationController < ActionController::Base
 
   protected
 
-   
   def configure_permitted_parameters
     # サインアップ時のストロングパラメータ
     devise_parameter_sanitizer.permit(:sign_up, keys: [:username])

--- a/app/controllers/tops_controller.rb
+++ b/app/controllers/tops_controller.rb
@@ -5,5 +5,7 @@ class TopsController < ApplicationController
 
   def index; end
 
-  def show; end
+  def show
+    render layout: 'application'
+  end
 end

--- a/app/controllers/users/confirmations_controller.rb
+++ b/app/controllers/users/confirmations_controller.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+class Users::ConfirmationsController < Devise::ConfirmationsController
+  # GET /resource/confirmation/new
+  # def new
+  #   super
+  # end
+
+  # POST /resource/confirmation
+  # def create
+  #   super
+  # end
+
+  # GET /resource/confirmation?confirmation_token=abcdef
+  # def show
+  #   super
+  # end
+
+  # protected
+
+  # The path used after resending confirmation instructions.
+  # def after_resending_confirmation_instructions_path_for(resource_name)
+  #   super(resource_name)
+  # end
+
+  # The path used after confirmation.
+  # def after_confirmation_path_for(resource_name, resource)
+  #   super(resource_name, resource)
+  # end
+end

--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -18,4 +18,9 @@ class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
       redirect_to new_user_registration_url
     end
   end
+
+  def after_sign_in_path_for(_resource)
+    tops_show_path
+  end
+  
 end

--- a/app/controllers/users/passwords_controller.rb
+++ b/app/controllers/users/passwords_controller.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+class Users::PasswordsController < Devise::PasswordsController
+  # GET /resource/password/new
+  # def new
+  #   super
+  # end
+
+  # POST /resource/password
+  # def create
+  #   super
+  # end
+
+  # GET /resource/password/edit?reset_password_token=abcdef
+  # def edit
+  #   super
+  # end
+
+  # PUT /resource/password
+  # def update
+  #   super
+  # end
+
+  # protected
+
+  # def after_resetting_password_path_for(resource)
+  #   super(resource)
+  # end
+
+  # The path used after sending reset password instructions
+  # def after_sending_reset_password_instructions_path_for(resource_name)
+  #   super(resource_name)
+  # end
+end

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+class Users::RegistrationsController < Devise::RegistrationsController
+  # before_action :configure_sign_up_params, only: [:create]
+  # before_action :configure_account_update_params, only: [:update]
+
+  # GET /resource/sign_up
+  # def new
+  #   super
+  # end
+
+  # POST /resource
+  # def create
+  #   super
+  # end
+
+  # GET /resource/edit
+  # def edit
+  #   super
+  # end
+
+  # PUT /resource
+  # def update
+  #   super
+  # end
+
+  # DELETE /resource
+  # def destroy
+  #   super
+  # end
+
+  # GET /resource/cancel
+  # Forces the session data which is usually expired after sign
+  # in to be expired now. This is useful if the user wants to
+  # cancel oauth signing in/up in the middle of the process,
+  # removing all OAuth session data.
+  # def cancel
+  #   super
+  # end
+
+  # protected
+
+  # If you have extra params to permit, append them to the sanitizer.
+  # def configure_sign_up_params
+  #   devise_parameter_sanitizer.permit(:sign_up, keys: [:attribute])
+  # end
+
+  # If you have extra params to permit, append them to the sanitizer.
+  # def configure_account_update_params
+  #   devise_parameter_sanitizer.permit(:account_update, keys: [:attribute])
+  # end
+
+  # The path used after sign up.
+  # def after_sign_up_path_for(resource)
+  #   super(resource)
+  # end
+
+  # The path used after sign up for inactive accounts.
+  # def after_inactive_sign_up_path_for(resource)
+  #   super(resource)
+  # end
+end

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -38,7 +38,17 @@ class Users::RegistrationsController < Devise::RegistrationsController
   #   super
   # end
 
-  # protected
+  protected
+
+  #アカウント登録後のリダイレクト先
+  def after_inactive_sign_up_path_for(_resource)
+    tops_show_path
+  end
+
+  #アカウント編集後のリダイレクト先
+  def after_update_path_for(resource)
+    tops_show_path
+  end
 
   # If you have extra params to permit, append them to the sanitizer.
   # def configure_sign_up_params

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -40,13 +40,13 @@ class Users::RegistrationsController < Devise::RegistrationsController
 
   protected
 
-  #アカウント登録後のリダイレクト先
+  # アカウント登録後のリダイレクト先
   def after_inactive_sign_up_path_for(_resource)
     tops_show_path
   end
 
-  #アカウント編集後のリダイレクト先
-  def after_update_path_for(resource)
+  # アカウント編集後のリダイレクト先
+  def after_update_path_for(_resource)
     tops_show_path
   end
 

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+class Users::SessionsController < Devise::SessionsController
+  # before_action :configure_sign_in_params, only: [:create]
+
+  # GET /resource/sign_in
+  # def new
+  #   super
+  # end
+
+  # POST /resource/sign_in
+  # def create
+  #   super
+  # end
+
+  # DELETE /resource/sign_out
+  # def destroy
+  #   super
+  # end
+
+  # protected
+
+  # If you have extra params to permit, append them to the sanitizer.
+  # def configure_sign_in_params
+  #   devise_parameter_sanitizer.permit(:sign_in, keys: [:attribute])
+  # end
+end

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -20,15 +20,15 @@ class Users::SessionsController < Devise::SessionsController
 
   protected
 
-  #ログイン後のリダイレクト先
-  def after_sign_in_path_for(resource)
+  # ログイン後のリダイレクト先
+  def after_sign_in_path_for(_resource)
     tops_show_path
-  end 
+  end
 
-  #ログアウト後のリダイレクト先
-  def after_sign_out_path_for(resource)
+  # ログアウト後のリダイレクト先
+  def after_sign_out_path_for(_resource)
     root_path
-  end 
+  end
 
   # If you have extra params to permit, append them to the sanitizer.
   # def configure_sign_in_params

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -18,7 +18,17 @@ class Users::SessionsController < Devise::SessionsController
   #   super
   # end
 
-  # protected
+  protected
+
+  #ログイン後のリダイレクト先
+  def after_sign_in_path_for(resource)
+    tops_show_path
+  end 
+
+  #ログアウト後のリダイレクト先
+  def after_sign_out_path_for(resource)
+    root_path
+  end 
 
   # If you have extra params to permit, append them to the sanitizer.
   # def configure_sign_in_params

--- a/app/controllers/users/unlocks_controller.rb
+++ b/app/controllers/users/unlocks_controller.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+class Users::UnlocksController < Devise::UnlocksController
+  # GET /resource/unlock/new
+  # def new
+  #   super
+  # end
+
+  # POST /resource/unlock
+  # def create
+  #   super
+  # end
+
+  # GET /resource/unlock?unlock_token=abcdef
+  # def show
+  #   super
+  # end
+
+  # protected
+
+  # The path used after sending unlock password instructions
+  # def after_sending_unlock_instructions_path_for(resource)
+  #   super(resource)
+  # end
+
+  # The path used after unlocking the resource
+  # def after_unlock_path_for(resource)
+  #   super(resource)
+  # end
+end

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -3,17 +3,13 @@
 // a relevant structure within app/javascript and only use these pack files to reference
 // that code so it'll be compiled.
 
-import Rails from "@rails/ujs"
-import Turbolinks from "turbolinks"
-import * as ActiveStorage from "@rails/activestorage"
-import "channels"
+// Bootstrap 5で、ProvidePluginを使う設定
+import jquery from "jquery"
+window.$ = window.jQuery = jquery
+import * as bootstrap from "bootstrap"
+window.bootstrap = bootstrap
 
-// 上で読み込んだものを起動
-Rails.start()
-Turbolinks.start()
-ActiveStorage.start()
-
-import '../stylesheets/application.scss'
+import '../stylesheets/application'
 
 // Uncomment to copy all static images under ../images to the output folder and reference
 // them with the image_pack_tag helper in views (e.g <%= image_pack_tag 'rails.png' %>)

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -9,6 +9,15 @@ window.$ = window.jQuery = jquery
 import * as bootstrap from "bootstrap"
 window.bootstrap = bootstrap
 
+import Rails from "@rails/ujs"
+import Turbolinks from "turbolinks"
+import * as ActiveStorage from "@rails/activestorage"
+import "channels"
+
+Rails.start()
+Turbolinks.start()
+ActiveStorage.start()
+
 import '../stylesheets/application'
 
 // Uncomment to copy all static images under ../images to the output folder and reference

--- a/app/javascript/stylesheets/application.scss
+++ b/app/javascript/stylesheets/application.scss
@@ -1,6 +1,10 @@
 @import '~bootstrap/scss/bootstrap.scss';
 
-
 .mw-md {
   max-width: 576px;
+}
+
+// ヘッダーとbodyの要素が被らないようにpaddingを設定
+body {
+  padding-top: 70px;
 }

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -39,7 +39,8 @@
 
 <hr class="devise-link my-5">
   <div class="form-group">
-    <%= link_to "トップページへ", root_path, class: 'btn btn-info w-100 mb-4' %>
+    <%# リンク先URLは掲示板ページへのパス %>
+    <%= link_to "トップページへ", tops_show_path, class: 'btn btn-info w-100 mb-4' %>
   </div>
 
   <div class="form-group">

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -13,6 +13,10 @@
   </head>
 
   <body>
+    <% unless controller.devise_controller? %>
+      <%= render 'shared/header' %>
+    <% end %>
+      
     <% if controller.devise_controller? %>
       <div class="container-fluid py-4 mw-md">
         <%= yield %>

--- a/app/views/layouts/tops.html.erb
+++ b/app/views/layouts/tops.html.erb
@@ -35,7 +35,7 @@
                             <li class="nav-item"><a class="nav-link" href="#portfolio">Portfolio</a></li>
                             <li class="nav-item"><strong><%= link_to current_user.username, tops_show_path, class: 'nav-link' %></strong></li>
                             <li class="nav-item"><%= link_to 'プロフィール変更', edit_user_registration_path, class: 'nav-link' %></li>
-                            <li class="nav-item"><%= link_to 'ログアウト', destroy_user_session_path, class: 'nav-link', method: :delete %></li>
+                            <li class="nav-item"><%= link_to 'ログアウト', destroy_user_session_path, class: 'nav-link', method: :get %></li>
                             <li class="nav-item"><a class="nav-link" href="#contact">Contact</a></li>
                         <% else %>
                             <li class="nav-item"><a class="nav-link" href="#about">About</a></li>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -17,12 +17,19 @@
           <li class="nav-item">
             <a class="nav-link" href="#">掲示板</a>
           </li>
+          <li class="nav-item">
+            <a class="nav-link" href="#">ニュース</a>
+          </li>
+          <li class="nav-item">
+            <a class="nav-link" href="#">試合日程</a>
+          </li>
           <li class="nav-item dropdown">
             <a class="nav-link dropdown-toggle" href="#" id="offcanvasNavbarDropdown" role="button" data-bs-toggle="dropdown" aria-expanded="false">
               ドロップダウン
             </a>
             <ul class="dropdown-menu" aria-labelledby="offcanvasNavbarDropdown">
               <li><a class="dropdown-item" href="#">マイページ</a></li>
+              <li><%= link_to 'プロフィール変更', edit_user_registration_path, class: 'dropdown-item' %></li>
               <li><%= link_to 'ログアウト', destroy_user_session_path, class: 'dropdown-item', method: :get %></li>
               <li>
                 <hr class="dropdown-divider">

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -1,7 +1,7 @@
 <nav class="navbar navbar-expand-lg bg-light fixed-top">
   <div class="container-fluid">
     <a class="navbar-brand" href="#">Liverpool One</a>
-    <button type="button" class="navbar-toggler" data-bs-toggle="offcanvas" data-bs-target="#offcanvasNavbar" aria-expanded="false" aria-controls="offcanvasNavbar">
+    <button type="button" class="navbar-light navbar-toggler" data-bs-toggle="offcanvas" data-bs-target="#offcanvasNavbar" aria-expanded="false" aria-controls="offcanvasNavbar">
       <span class="navbar-toggler-icon"></span>
     </button>
     <div class="offcanvas offcanvas-end" tabindex="-1" id="offcanvasNavbar" aria-labelledby="offcanvasNavbarLabel">

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -30,7 +30,7 @@
             <ul class="dropdown-menu" aria-labelledby="offcanvasNavbarDropdown">
               <li><a class="dropdown-item" href="#">マイページ</a></li>
               <li><%= link_to 'プロフィール変更', edit_user_registration_path, class: 'dropdown-item' %></li>
-              <li><%= link_to 'ログアウト', destroy_user_session_path, class: 'dropdown-item', method: :get %></li>
+              <li><%= link_to 'ログアウト', destroy_user_session_path, class: 'dropdown-item', method: :delete %></li>
               <li>
                 <hr class="dropdown-divider">
               </li>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -1,0 +1,41 @@
+<nav class="navbar navbar-expand-lg bg-light fixed-top">
+  <div class="container-fluid">
+    <a class="navbar-brand" href="#">Liverpool One</a>
+    <button type="button" class="navbar-toggler" data-bs-toggle="offcanvas" data-bs-target="#offcanvasNavbar" aria-expanded="false" aria-controls="offcanvasNavbar">
+      <span class="navbar-toggler-icon"></span>
+    </button>
+    <div class="offcanvas offcanvas-end" tabindex="-1" id="offcanvasNavbar" aria-labelledby="offcanvasNavbarLabel">
+      <div class="offcanvas-header">
+        <h5 class="offcanvas-title" id="offcanvasNavbarLabel">Liverpool One</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="offcanvas" aria-label="閉じる"></button>
+      </div>
+      <div class="offcanvas-body">
+        <ul class="navbar-nav justify-content-end flex-grow-1 pe-3">
+          <li class="nav-item">
+            <a class="nav-link active" aria-current="page" href="#">ホーム</a>
+          </li>
+          <li class="nav-item">
+            <a class="nav-link" href="#">掲示板</a>
+          </li>
+          <li class="nav-item dropdown">
+            <a class="nav-link dropdown-toggle" href="#" id="offcanvasNavbarDropdown" role="button" data-bs-toggle="dropdown" aria-expanded="false">
+              ドロップダウン
+            </a>
+            <ul class="dropdown-menu" aria-labelledby="offcanvasNavbarDropdown">
+              <li><a class="dropdown-item" href="#">マイページ</a></li>
+              <li><%= link_to 'ログアウト', destroy_user_session_path, class: 'dropdown-item', method: :get %></li>
+              <li>
+                <hr class="dropdown-divider">
+              </li>
+              <li><a class="dropdown-item" href="#">その他</a></li>
+            </ul>
+          </li>
+        </ul>
+        <form class="d-flex" role="search">
+          <input type="search" class="form-control me-2" placeholder="検索" aria-label="検索">
+          <button class="btn btn-outline-success flex-shrink-0" type="submit">検索</button>
+        </form>
+      </div>
+    </div>
+  </div>
+</nav>

--- a/app/views/tops/show.html.erb
+++ b/app/views/tops/show.html.erb
@@ -1,2 +1,7 @@
+<%# ここに掲示板の画面を設置 %>
+
+<p class="notice alert-success"><%= notice %></p>
+<p class="alert"><%= alert %></p>
+
 <h1>こんにちは、<%= current_user.username %>さん</h1>
 <p>ユーザー用ページです。</p>

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -266,7 +266,7 @@ Devise.setup do |config|
   # config.navigational_formats = ['*/*', :html]
 
   # The default HTTP method used to sign out a resource. Default is :delete.
-  config.sign_out_via = :delete
+  config.sign_out_via = :get
 
   # ==> OmniAuth
   # Add a new OmniAuth provider. Check the wiki for more information on setting

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -266,7 +266,7 @@ Devise.setup do |config|
   # config.navigational_formats = ['*/*', :html]
 
   # The default HTTP method used to sign out a resource. Default is :delete.
-  config.sign_out_via = :get
+  config.sign_out_via = :delete
 
   # ==> OmniAuth
   # Add a new OmniAuth provider. Check the wiki for more information on setting

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,6 +3,11 @@
 Rails.application.routes.draw do
   root 'tops#index'
   get 'tops/show'
-  devise_for :users, controllers: { omniauth_callbacks: 'users/omniauth_callbacks' }
+  devise_for :users, controllers: {
+    omniauth_callbacks: 'users/omniauth_callbacks',
+    sessions: "users/sessions",
+    registrations: "users/registrations"
+  }
+
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,8 +5,8 @@ Rails.application.routes.draw do
   get 'tops/show'
   devise_for :users, controllers: {
     omniauth_callbacks: 'users/omniauth_callbacks',
-    sessions: "users/sessions",
-    registrations: "users/registrations"
+    sessions: 'users/sessions',
+    registrations: 'users/registrations'
   }
 
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html


### PR DESCRIPTION
## 概要

- ヘッダー以外のリンクに関しては後程実装するので、このブランチでのリンク先のURLは`'#'`で設定

- ログイン後のViewを下記の様にする

[![Image from Gyazo](https://i.gyazo.com/1a1b6aa90a71078b66080d66b4dfc292.png)](https://gyazo.com/1a1b6aa90a71078b66080d66b4dfc292)

## 確認方法

1. ログイン後のView（tops_show_path）にヘッダーであるナビバーがあること
2. 通常ログイン、Twitterログイン共にログイン後の遷移先が`tops_show_path`であること
3. 「ログアウト」「プロフィール変更」以外のナビバーリンクには遷移先があること

[![Image from Gyazo](https://i.gyazo.com/8f0a069f132de25d64fd1a5ea3a74a5b.png)](https://gyazo.com/8f0a069f132de25d64fd1a5ea3a74a5b)