### PR TITLE
GA（Google アナリティクス）を導入

### DIFF
--- a/app/views/layouts/_google_analytics.html.erb
+++ b/app/views/layouts/_google_analytics.html.erb
@@ -1,0 +1,9 @@
+<!-- Global site tag (gtag.js) - Google Analytics -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-QWZGT2FDXP"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', 'G-QWZGT2FDXP');
+</script>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -11,6 +11,10 @@
 
     <%= stylesheet_pack_tag 'application', media: 'all', 'data-turbolinks-track': 'reload' %>
     <%= javascript_pack_tag 'application', 'data-turbolinks-track': 'reload' %>
+
+    <% if Rails.env.production? %>
+      <%= render 'layouts/google_analytics' %>
+    <% end %>
   </head>
 
   <body>

--- a/app/views/layouts/top.html.erb
+++ b/app/views/layouts/top.html.erb
@@ -20,7 +20,12 @@
         <link href="https://fonts.googleapis.com/css?family=Merriweather:400,300,300italic,400italic,700,700italic" rel="stylesheet" type="text/css" />
         <!-- SimpleLightbox plugin CSS-->
         <link href="https://cdnjs.cloudflare.com/ajax/libs/SimpleLightbox/2.1.0/simpleLightbox.min.css" rel="stylesheet" />
+
+        <% if Rails.env.production? %>
+            <%= render 'layouts/google_analytics' %>
+        <% end %>
     </head>
+    
     <body id="page-top">
         <!-- Navigation-->
         <nav class="navbar navbar-expand-lg navbar-light fixed-top py-3" id="mainNav">


### PR DESCRIPTION
## 概要

- オーガニックからの流入数値を記録するために導入する

- 何経由（google検索やSNS、他社サイトから等）でWebサイトを訪れたのかを記録するため

## 確認方法

1. アプリケーションの全ページでGAが読み込まれていること
2. googleアカウントから下記画像のように数値を確認できること

[![Image from Gyazo](https://i.gyazo.com/ead56eb53b2bc66c5973792504387f99.png)](https://gyazo.com/ead56eb53b2bc66c5973792504387f99)
