### PR TITLE
Update: GoogleアナリティクスにHerokuに設定した独自ドメインを追加

### DIFF
--- a/app/views/layouts/_google_analytics.html.erb
+++ b/app/views/layouts/_google_analytics.html.erb
@@ -6,4 +6,11 @@
   gtag('js', new Date());
 
   gtag('config', 'G-QWZGT2FDXP');
+
+  gtag('config', 'UA-234717377-2', {
+    'accept_incoming': true,
+    'linker': {
+      'domains': ['www.liverpool-one1.com']
+    }
+  });
 </script>


### PR DESCRIPTION
## 概要

・GoogleアナリティクスにHerokuに設定した独自ドメインを設定する


## 確認方法

1. GAアナリティクスの画面でリアルタイムレポートにドメインの情報が記録されていること
